### PR TITLE
Encode ticker in url before calling yfinance api

### DIFF
--- a/src/main/kotlin/sh/huang/finance/dataproviders/yfinance/YahooFinanceClient.kt
+++ b/src/main/kotlin/sh/huang/finance/dataproviders/yfinance/YahooFinanceClient.kt
@@ -5,6 +5,8 @@ import com.google.gson.reflect.TypeToken
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -13,7 +15,8 @@ import org.springframework.stereotype.Component
 import sh.huang.finance.constant.ExchangeConstant
 import sh.huang.finance.generated.tables.daos.YfinanceCacheDao
 import sh.huang.finance.generated.tables.pojos.YfinanceCache
-import sh.huang.finance.job.StockHistorySyncJob
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -72,7 +75,10 @@ class YahooFinanceClient {
             }
         }
 
-        val url = "${yfinanceUrl}/ticker/${ticker}"
+        val encodedTicker = withContext(Dispatchers.IO) {
+            URLEncoder.encode(ticker, StandardCharsets.UTF_8.toString())
+        }
+        val url = "${yfinanceUrl}/ticker/${encodedTicker}"
 
         val response = httpClient.get(url)
         val json = response.bodyAsText()


### PR DESCRIPTION
Some tickers may container char `^` that causes illegal character in url. Need to encode ticker to construct url

```bash
java.net.URISyntaxException: Illegal character in path at index 33: http://localhost:5001/ticker/YCBD^A
        at java.base/java.net.URI$Parser.fail(URI.java:2995) ~[na:na]
        at java.base/java.net.URI$Parser.checkChars(URI.java:3166) ~[na:na]
        at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3248) ~[na:na]
        at java.base/java.net.URI$Parser.parse(URI.java:3196) ~[na:na]
        at java.base/java.net.URI.<init>(URI.java:645) ~[na:na]
        at io.ktor.http.URLUtilsJvmKt.toURI(URLUtilsJvm.kt:57) ~[ktor-http-jvm-2.3.8.jar:2.3.8]
        at io.ktor.client.engine.apache5.ApacheRequestProducerKt.setupRequest(ApacheRequestProducer.kt:60) ~[ktor-client-apache5-jvm-2.3.8.jar:2.3.8]
        at io.ktor.client.engine.apache5.ApacheRequestProducerKt.ApacheRequestProducer(ApacheRequestProducer.kt:49) ~[ktor-client-apache5-jvm-2.3.8.jar:2.3.8]
        at io.ktor.client.engine.apache5.Apache5Engine.execute(Apache5Engine.kt:41) ~[ktor-client-apache5-jvm-2.3.8.jar:2.3.8]
        at io.ktor.client.engine.HttpClientEngine$executeWithinCallContext$2.invokeSuspend(HttpClientEngine.kt:99) ~[ktor-client-core-jvm-2.3.8.jar:2.3.8]
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33) ~[kotlin-stdlib-1.9.22.jar:1.9.22-release-704]
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108) ~[kotlinx-coroutines-core-jvm-1.7.3.jar:na]
        at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:115) ~[kotlinx-coroutines-core-jvm-1.7.3.jar:na]
        at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:103) ~[kotlinx-coroutines-core-jvm-1.7.3.jar:na]
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584) ~[kotlinx-coroutines-core-jvm-1.7.3.jar:na]
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:793) ~[kotlinx-coroutines-core-jvm-1.7.3.jar:na]
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:697) ~[kotlinx-coroutines-core-jvm-1.7.3.jar:na]
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:684) ~[kotlinx-coroutines-core-jvm-1.7.3.jar:na]
```